### PR TITLE
Support pretty permalinks in Nginx by default

### DIFF
--- a/content/plugins-mu/hm-base-environment.php
+++ b/content/plugins-mu/hm-base-environment.php
@@ -1,0 +1,4 @@
+<?php
+
+// Remove annoying index.php in permalinks settings with Nginx.
+add_filter( 'got_rewrite', '__return_true', 999 );


### PR DESCRIPTION
See: http://danielbachhuber.com/2011/02/10/wordpress-pretty-permalinks-with-nginx/

We've been getting around it by setting a custom permastruct in the admin. We should just include this filter in an "environment" file instead.

Related core ticket and discussion: http://core.trac.wordpress.org/ticket/18852
