### PR TITLE
Login redirect bug

### DIFF
--- a/content/plugins-mu/hm-base-environment.php
+++ b/content/plugins-mu/hm-base-environment.php
@@ -2,3 +2,30 @@
 
 // Remove annoying index.php in permalinks settings with Nginx.
 add_filter( 'got_rewrite', '__return_true', 999 );
+
+/**
+ * Fix login loop.
+ *
+ * If you go to /wp-admin/ when wordpress is in a subdirectory, it cleverly redirects you to /subdir/wp-login.ph
+ * But... it appends reauth=1 to the url... which forces a reauthentication on a succesful login... wierd right!
+ */
+// add_filter( 'login_url', function( $url ) {
+
+// 	if ( '/wp-admin/' === add_query_arg( array() ) ) {
+// 		$url = remove_query_arg( 'reauth', $url );
+// 		$url = add_query_arg( 'redirect_to', get_admin_url(), $url );
+// 	}
+	
+// 	return $url;
+
+// } );
+
+
+
+// add_action( 'wp_head', function() {
+
+// 	global $wp_rewrite;
+
+// 	hm( $wp_rewrite );
+
+// } );

--- a/content/plugins-mu/hm-base-environment.php
+++ b/content/plugins-mu/hm-base-environment.php
@@ -9,23 +9,13 @@ add_filter( 'got_rewrite', '__return_true', 999 );
  * If you go to /wp-admin/ when wordpress is in a subdirectory, it cleverly redirects you to /subdir/wp-login.ph
  * But... it appends reauth=1 to the url... which forces a reauthentication on a succesful login... wierd right!
  */
-// add_filter( 'login_url', function( $url ) {
+add_filter( 'login_url', function( $url ) {
 
-// 	if ( '/wp-admin/' === add_query_arg( array() ) ) {
-// 		$url = remove_query_arg( 'reauth', $url );
-// 		$url = add_query_arg( 'redirect_to', get_admin_url(), $url );
-// 	}
+	if ( '/wp-admin/' === add_query_arg( array() ) ) {
+		$url = remove_query_arg( 'reauth', $url );
+		$url = add_query_arg( 'redirect_to', get_admin_url(), $url );
+	}
 	
-// 	return $url;
+	return $url;
 
-// } );
-
-
-
-// add_action( 'wp_head', function() {
-
-// 	global $wp_rewrite;
-
-// 	hm( $wp_rewrite );
-
-// } );
+} );


### PR DESCRIPTION
I have an issue where I go to `site.dev/wp-admin` and get redirected to `site.dev/wordpress/wp-admin` which is great... except that `reauth=1` gets appended to the url. Which causes a logout as soon as I try and log in.

We should probably be handleing this at the level that the redirect is happening - but I can't for the life of me work out where this is... 

I noticed Joel was experiencing this issue too - although he had got pretty used to it and always remembered to remove the query args from the url.
