### PR TITLE
Allow file mods for dev

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -91,8 +91,9 @@ define( 'WPMU_PLUGIN_DIR', dirname( __FILE__ ) . '/content/plugins-mu' );
 define( 'WPMU_PLUGIN_URL', WP_HOME . '/content/plugins-mu' );
 
 // Prevent editing of files through the admin.
+// Enable installing and upgrading plugins for dev sites.
 define( 'DISALLOW_FILE_EDIT', true );
-define( 'DISALLOW_FILE_MODS', true );
+define( 'DISALLOW_FILE_MODS', HM_DEV ? false : true );
 
 if ( ! HM_DEV ) {
 	defined( 'WP_CACHE' ) OR define( 'WP_CACHE', true );

--- a/wp-config.php
+++ b/wp-config.php
@@ -93,7 +93,7 @@ define( 'WPMU_PLUGIN_URL', WP_HOME . '/content/plugins-mu' );
 // Prevent editing of files through the admin.
 // Enable installing and upgrading plugins for dev sites.
 define( 'DISALLOW_FILE_EDIT', true );
-define( 'DISALLOW_FILE_MODS', HM_DEV ? false : true );
+define( 'DISALLOW_FILE_MODS', ! HM_DEV );
 
 if ( ! HM_DEV ) {
 	defined( 'WP_CACHE' ) OR define( 'WP_CACHE', true );


### PR DESCRIPTION
Typical workflow: 

Install/update plugins locally and commit to git. Test locally, deploy live.

However you can't do this because we're preventing file mods. This is great because users can't try and add plugins themselves. But bad for us because neither can we.

Solution is to enable/disable this locally for us if HM_DEV is true. This way we can see any updates and install new plugins with ease, yet users still can't do it. 