### PR TITLE
Switch to Official WordPress Git Mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "content/plugins-mu/mandrill-wp-mail"]
 	path = content/plugins-mu/mandrill-wp-mail
 	url = git@github.com:danielbachhuber/mandrill-wp-mail.git
+[submodule "wordpress"]
+	path = wordpress
+	url = git://core.git.wordpress.org/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "wordpress"]
-	path = wordpress
-	url = https://github.com/WordPress/WordPress.git
 [submodule "content/plugins-mu/s3-uploads"]
 	path = content/plugins-mu/s3-uploads
 	url = git@github.com:humanmade/S3-Uploads.git


### PR DESCRIPTION
Fixes #24 until we have our own HM Git Mirror on Github of the Official WordPress Git Mirror. 