### PR TITLE
Add Cache-Control Headers for 1 year for S3 Uploads

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -99,6 +99,9 @@ define( 'WPMU_PLUGIN_URL', WP_HOME . '/content/plugins-mu' );
 define( 'DISALLOW_FILE_EDIT', true );
 define( 'DISALLOW_FILE_MODS', true );
 
+// Add Cache Control headers for 1 year to S3 Uploads.
+defined( 'S3_UPLOADS_CACHE_CONTROL' ) or define( 'S3_UPLOADS_CACHE_CONTROL', 60 * 60 * 24 * 365 );
+
 if ( ! HM_DEV ) {
 	defined( 'WP_CACHE' ) OR define( 'WP_CACHE', true );
 }


### PR DESCRIPTION
I think we're adding this upstream in our CloudFront distro but we might as well add it here as well.