### PR TITLE
Remove `Icon?` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ query-monitor/
 ### OS and Software generated files ###
 .DS_Store
 ehthumbs.db
-Icon?
 Thumbs.db
 ._*
 .idea/


### PR DESCRIPTION
This regularly causes us to accidentally leave out icon font files and similarly named directories during development because we aren't aware they are excluded, until we deploy to a staging server.

I've recently been caught by this on a client project, and @sambulance has too, on another project. I'm sure we aren't the only ones!