### PR TITLE
Check for _SERVER var first before using it

### DIFF
--- a/wp-config-local-sample.php
+++ b/wp-config-local-sample.php
@@ -5,5 +5,7 @@ define( 'DB_USER', 'root' );
 define( 'DB_PASSWORD', '' );
 define( 'DB_HOST', 'localhost' );
 
-define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/wordpress' );
-define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] );
+if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+	define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] );
+	define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/wordpress' );
+}


### PR DESCRIPTION
Fixes a problem with wp-cli where no HTTP_HOST variable is defined.

A `wp-cli.yml` file with `url` value would fix this, but if it does not exist, an error message is displayed on every wp-cli command.