### PR TITLE
Allow overriding WP_CONTENT_* / WPMU_PLUGIN_*

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -80,20 +80,18 @@ define( 'WPLANG', '' );
 define( 'DB_CHARSET', 'utf8mb4' );
 
 // Define Site URL: WordPress in a subdirectory.
-if ( ! defined( 'WP_SITEURL' ) )
-	define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] );
+defined( 'WP_SITEURL' )      or define( 'WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] );
 
 // Define Home URL
-if ( ! defined( 'WP_HOME' ) )
-	define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] );
+defined( 'WP_HOME' )         or define( 'WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] );
 
 // Define path & url for Content
-define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
-define( 'WP_CONTENT_URL', WP_HOME . '/content' );
+defined( 'WP_CONTENT_DIR' )  or define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );
+defined( 'WP_CONTENT_URL' )  or define( 'WP_CONTENT_URL', WP_HOME . '/content' );
 
 // Set path to MU Plugins.
-define( 'WPMU_PLUGIN_DIR', dirname( __FILE__ ) . '/content/plugins-mu' );
-define( 'WPMU_PLUGIN_URL', WP_HOME . '/content/plugins-mu' );
+defined( 'WPMU_PLUGIN_DIR' ) or define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins-mu' );
+defined( 'WPMU_PLUGIN_URL' ) or define( 'WPMU_PLUGIN_URL', WP_CONTENT_URL . '/plugins-mu' );
 
 // Prevent editing of files through the admin.
 // Enable installing and upgrading plugins for dev sites.


### PR DESCRIPTION
- Allow overriding WP_CONTENT_* / WPMU_PLUGIN_*
- Simpler `defined` checks
- Use WP_CONTENT_* within WPMU_PLUGIN_* instead of rewriting the subfolder