### PR TITLE
Update circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ test:
     - find -L ./ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l > /dev/null
     - mysql -e 'create database wp_tests;'
   override:
-    - phpunit
+    - phpunit --log-junit $CIRCLE_TEST_REPORTS/phpunit/junit.xml
     - ./php-codesniffer/scripts/phpcs -p --extensions=php --standard=./codesniffer-ruleset.xml ./ -v -q
     - php -S 127.0.0.1:8080:
         background: true


### PR DESCRIPTION
Circle recommends having the test runners output in JUnit-style XML because it adds a few extra niceties:
- Show a summary of all test failures across all containers
- Identify your slowest tests
- Balance tests between containers when using properly configured parallelization