### PR TITLE
Add templates for issues and PRs.

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,18 @@
+## New Feature Request
+
+### Description
+
+### Acceptance criteria
+
+## Bug
+
+### Expected vs. actual behaviour
+
+### Steps to reproduce
+
+### Screenshots (if appropriate)
+
+### Environment
+- Device
+- Operating system
+- Browser

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,0 +1,10 @@
+## Issue reference
+
+## Steps to test
+
+## Screenshots: before and after (if appropriate)
+
+## Checklist
+- [ ] Unit tests?
+- [ ] Link to page on develop or staging for testing?
+- [ ] Any documentation changes needed?


### PR DESCRIPTION
This is somewhat opinionated, but issue and PR templates have been very helpful on past projects, yet it's something I continue to forget setting up.

Not against modifying these templates, the important thing for them is to be there to have a starting point, and remind developers of the existence of this tool.