### PR TITLE
Update README.md for WP 4.9.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ git commit -m 'Update hm-platform to latest'
 
 # Update WordPress.
 cd wordpress
-git checkout 4.9.7
+git checkout 4.9.8
 cd ..
 git add wordpress
-git commit -m 'Update WordPress to 4.9.7'
+git commit -m 'Update WordPress to 4.9.8'
 
 # Remove the hm-base remote:
 git remote rm origin


### PR DESCRIPTION
This updates the setup instructions to assume the use of WordPress 4.9.8, which is the current released version at the time of this commit.