### PR TITLE
Add .envrc and wp-cli config for host machine

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+export VAGRANT_CWD=$( pwd )/chassis
+export WP_CLI_CONFIG_PATH=$( pwd )/wp-cli.host.yml

--- a/wp-cli.host.yml
+++ b/wp-cli.host.yml
@@ -1,0 +1,2 @@
+ssh: vagrant:default
+path: /chassis/wordpress


### PR DESCRIPTION
This allows developers using `direnv` to run `vagrant` or `wp` commands from anywhere in the project repository instead of having to cd into the `chassis` subdirectory.

(Note: I'm not sure if this belongs in hm-base or not; feel free if close if it doesn't belong here. I've found these files useful and have been copying them into the last few projects I've worked on, and I think they would be good to standardize on...)