### PR TITLE
Add example composer.json File

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 		}
 	],
 	"require-dev": {
-		"phpunit/phpunit": "5.7",
 		"humanmade/coding-standards": "0.5.0"
 	},
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,6 @@
 	"name": "hm-base",
 	"license": "GPL V3+",
 	"minimum-stability": "stable",
-	"config": {
-		"vendor-dir": "content/plugins-mu/vendor"
-	},
 	"repositories": [
 		{
 			"type": "composer",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+	"name": "hm-base",
+	"license": "GPL V3+",
+	"minimum-stability": "stable",
+	"config": {
+		"vendor-dir": "content/plugins-mu/vendor"
+	},
+	"repositories": [
+		{
+			"type": "composer",
+			"url": "https://wpackagist.org"
+		}
+	],
+	"require-dev": {
+		"phpunit/phpunit": "5.7",
+		"humanmade/coding-standards": "0.5.0"
+	},
+	"require": {
+		"oomphinc/composer-installers-extender": "*"
+	},
+	"extra": {
+		"installer-types": [
+			"library"
+		],
+		"installer-paths": {
+			"content/plugins-mu/{$name}/": [
+				"type:wordpress-muplugin"
+			],
+			"content/plugins/{$name}/": [
+				"type:wordpress-plugin"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an example composer.json file that should get a project started up a little faster if using `hm-base` for reference. It includes our coding standards, the correct PHPUnit version, and installers to allow for more complicated routing patterns.

Anything to add or change from this?
