### PR TITLE
Gitignore` /vendor/` Dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ uploads/
 wpremote
 *-backups
 /node_modules/
+/vendor/
 
 ### WordPress local dev ###
 wp-config-local.php


### PR DESCRIPTION
I neglected to ignore the `/vendor` directory when adding the Composer configration. this fixes that oversight.