### PR TITLE
Remove all references of Grunt

### DIFF
--- a/.build-script
+++ b/.build-script
@@ -10,7 +10,5 @@ set -e
 
 # Run any build pieces you need here. For example:
 
-#npm install -g grunt
 #cd content/themes/projecttheme/
 #npm install
-#grunt


### PR DESCRIPTION
@sambulance rightly pointed out that we still have references to Grunt in the codebase and that we should remove them. Completed here.

Resolves #61