### PR TITLE
First pass at Gutenberg project boilerplate MU plugin

### DIFF
--- a/content/mu-plugins/blocks/blocks.php
+++ b/content/mu-plugins/blocks/blocks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: HM Blocks
+ *
+ * @package HM
+ */
+
+namespace HM\Gutenberg_Blocks;
+
+// We use this constant to enqueue development assets, which is more flexible than relative paths.
+const ROOT_DIR = __DIR__;
+
+// Load helpers first, so that other code can rely on them.
+require_once __DIR__ . '/inc/helpers.php';
+require_once __DIR__ . '/inc/assets.php';
+require_once __DIR__ . '/inc/blocks.php';
+
+// Bootstrap the helpers.
+Assets\bootstrap();
+Blocks\bootstrap();

--- a/content/mu-plugins/blocks/inc/assets.php
+++ b/content/mu-plugins/blocks/inc/assets.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Handle asset enqueuing in development and build mode.
+ *
+ * @package HM
+ */
+
+namespace HM\Gutenberg_Blocks\Assets;
+
+use const HM\Gutenberg_Blocks\ROOT_DIR;
+use function HM\Gutenberg_Blocks\Helpers\get_supported_blocks;
+use HM\Asset_Loader;
+
+/**
+ * Add hooks.
+ */
+function bootstrap() {
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_assets', 1 );
+}
+
+/**
+ * Enqueue the block JS and CSS assets depending on the current asset building mode.
+ */
+function enqueue_assets() {
+	// Find out whether we are in development or build mode.
+	$is_dev_mode = Asset_Loader\get_webpack_dev_server_assets_list( ROOT_DIR );
+
+	if ( $is_dev_mode ) {
+		// Enqueue the development assets from the Webpack dev server.
+		Asset_Loader\enqueue_webpack_dev_server_assets(
+			ROOT_DIR,
+			[
+				'handle'  => 'hm-gb-blocks-dev',
+				'scripts' => [ 'wp-blocks', 'wp-element', 'wp-url', 'wp-components', 'wp-editor' ],
+			]
+		);
+
+		// Attach JS dependencies to the Core editor script.
+		$handle = 'wp-editor';
+	} else {
+		// Enqueue the build versions of the block JS and CSS.
+		wp_enqueue_script(
+			'hm-gb-blocks',
+			plugins_url( '/build/index.js', dirname( __FILE__ ) ),
+			[ 'wp-blocks', 'wp-element', 'wp-url', 'wp-components', 'wp-editor' ],
+			Asset_Loader\get_asset_version(),
+			true
+		);
+
+		wp_enqueue_style(
+			'hm-gb-blocks',
+			plugins_url( '/build/style.css', dirname( __FILE__ ) ),
+			[],
+			Asset_Loader\get_asset_version()
+		);
+
+		// Attach JS dependencies to the main blocks file.
+		$handle = 'hm-gb-blocks';
+	}
+
+	// Deregister the block library theme styles.
+	// This cannot easily be dequeued or deregistered as it is a dependency of other styles.
+	// Work around this by registering a new style with a blank src.
+	// The styles from this file have been copied into the base theme editor.scss (and modified).
+	wp_deregister_style( 'wp-block-library-theme' );
+	wp_register_style( 'wp-block-library-theme', '' );
+
+	// Output an object with the blocks supported by the current theme.
+	wp_localize_script( $handle, 'HMCurrentThemeBlockSupport', get_supported_blocks() );
+}

--- a/content/mu-plugins/blocks/inc/blocks.php
+++ b/content/mu-plugins/blocks/inc/blocks.php
@@ -1,0 +1,21 @@
+<?php
+namespace HM\Gutenberg_Blocks\Blocks;
+
+use Exception;
+use function HM\Gutenberg_Blocks\Helpers\get_supported_blocks;
+use const HM\Gutenberg_Blocks\ROOT_DIR;
+
+function bootstrap() {
+	add_action( 'after_setup_theme', __NAMESPACE__ . '\\block_loader', 100 );
+}
+
+// TODO - maybe some kind of autoloading?
+function get_available_blocks() {
+	$blocks_dir = ROOT_DIR . '/src/blocks';
+	$supported_blocks = get_supported_blocks();
+
+	if ( in_array( 'hmn/example', $supported_blocks, true ) ) {
+		require_once $blocks_dir . '/example/index.php';
+		Example\bootstrap();
+	}
+}

--- a/content/mu-plugins/blocks/inc/helpers.php
+++ b/content/mu-plugins/blocks/inc/helpers.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Helper functions
+ */
+
+namespace HM\Gutenberg_Blocks\Helpers;
+
+/**
+ * Hackish solution to distinguish between block renders on the front end, and the back end.
+ *
+ * In the admin, the global `$wp_query` does not contain a query. We use this to determine whether a rendering is
+ * happening on the front end or the back end.
+ *
+ * @return bool Whether we're in the admin or on the front end.
+ */
+function is_front_end_query() {
+	return ! empty( $GLOBALS['wp_query']->query );
+}
+
+/**
+ * Get Red Bull Media Hub blocks that are currently enabled.
+ *
+ * Can also be filtered using the filter `hm_blocks`.
+ *
+ * @return array Array of block names.
+ */
+function get_supported_blocks() {
+	$theme_support = get_theme_support( 'hm-blocks' );
+	return apply_filters( 'hm_blocks', isset( $theme_support[0] ) ? $theme_support[0] : [] );
+}

--- a/content/mu-plugins/blocks/src/blocks/default.js
+++ b/content/mu-plugins/blocks/src/blocks/default.js
@@ -1,0 +1,22 @@
+/**
+ * A default block config with some common configurations.
+ * When creating new block types, this can be extended to avoid having to declare the same things for all blocks.
+ */
+export default {
+	// Default category.
+	category: 'common',
+	// Default icon.
+	icon: 'wordpress-alt',
+	// By default, save to return null. Commonly used if your data is stored in as JSON only.
+	save() {
+		return null;
+	},
+	// By default, disable additional css class field and editing as html.
+	supports: {
+		// Remove "Additional CSS Class" field from the Advanced tab in the editor sidebar.
+		// Unless your code supports this, it has no effect.
+		customClassName: false,
+		// Do not allow the block's HTML to be edited.
+		html: false,
+	},
+};

--- a/content/mu-plugins/blocks/src/blocks/example/edit.js
+++ b/content/mu-plugins/blocks/src/blocks/example/edit.js
@@ -1,0 +1,36 @@
+/* global wp */
+
+const { Fragment } = wp.element;
+const { InspectorControls } = wp.editor;
+const { __ } = wp.i18n;
+const {
+	PanelBody,
+	TextControl,
+} = wp.components;
+
+export default ( {
+	attributes,
+	name: blockName,
+	setAttributes,
+} ) => {
+	const {
+		title,
+	} = attributes;
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Block Settings' ) }>
+					<TextControl
+						label={ __( 'Block title' ) }
+						onChange={ title => setAttributes( { title } ) }
+						value={ title }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div>
+				{ blockName }
+			</div>
+		</Fragment>
+	);
+};

--- a/content/mu-plugins/blocks/src/blocks/example/editor.scss
+++ b/content/mu-plugins/blocks/src/blocks/example/editor.scss
@@ -1,0 +1,5 @@
+.hmn-example-block {
+	padding: 20px;
+	background: rgba( 255, 0, 0, 0.5 );
+	font-weight: bold;
+}

--- a/content/mu-plugins/blocks/src/blocks/example/example.php
+++ b/content/mu-plugins/blocks/src/blocks/example/example.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Hero Block.
+ *
+ * @package HM
+ */
+
+namespace HM\Gutenberg_Blocks\Example;
+
+/**
+ * Set up hooks.
+ */
+function bootstrap() {
+	add_action( 'init', __NAMESPACE__ . '\\register_block' );
+}
+
+/**
+ * Register the block.
+ */
+function register_block() {
+	$options = [
+		'attributes' => [
+			'heading' => [
+				'type' => 'string',
+			],
+			'subHeading' => [
+				'type' => 'string',
+			],
+		],
+		'render_callback' => __NAMESPACE__ . '\\render_block',
+
+	];
+
+	register_block_type(
+		'hmn/example',
+		$options
+	);
+}
+
+/**
+ * Render the block on the front end.
+ *
+ * @param array $attributes Array of attributes extracted from the block markup.
+ *
+ * @return string Block HTML
+ */
+function render_block( $attributes = [] ) {
+	ob_start();
+
+	var_dump( $attributes );
+
+	return ob_get_clean();
+}

--- a/content/mu-plugins/blocks/src/blocks/example/index.js
+++ b/content/mu-plugins/blocks/src/blocks/example/index.js
@@ -1,0 +1,16 @@
+/* global wp */
+
+import edit from './edit';
+import defaultOptions from '../default';
+
+const { __ } = wp.i18n;
+
+export const name = 'hmn/example';
+
+export const options = {
+	// Extend the default block.
+	...defaultOptions,
+	description: __( 'Just a little test.' ),
+	edit,
+	title: __( 'HM Test' ),
+}

--- a/content/mu-plugins/blocks/src/blocks/example/readme.md
+++ b/content/mu-plugins/blocks/src/blocks/example/readme.md
@@ -1,0 +1,10 @@
+# Example block.
+
+This directory should be named the same as the block name (not including namespace)
+
+1. `index.js`. This is the entry point for the file
+	* Shoud export `name` containing the block name and namespace e.g. `hmn/example`
+	* Should export `options` - an object with all the block options.
+2. The edit UI sould be split into a separate component in `edit.js`
+3. (optional) `index.php` This is the PHP entry point, required if you are registering the block in PHP.
+4. (optional) `style.scss`. If your block has any custom styles, add them here.

--- a/content/mu-plugins/blocks/src/blocks/readme.md
+++ b/content/mu-plugins/blocks/src/blocks/readme.md
@@ -1,0 +1,7 @@
+# Blocks
+
+Define Blocks
+
+Each file should export:
+- name. String. The block name including namespace. e.g. `hmn/example`
+- options. Object. The block options.

--- a/content/mu-plugins/blocks/src/components/readme.md
+++ b/content/mu-plugins/blocks/src/components/readme.md
@@ -1,0 +1,5 @@
+# Components
+
+Generic and reusable components.
+
+It should be encouraged to build any UI elements for your blocks as reusable components, rather than building too much into a single block edit component.

--- a/content/mu-plugins/blocks/src/index.js
+++ b/content/mu-plugins/blocks/src/index.js
@@ -1,0 +1,18 @@
+/* global wp */
+
+// Import the blocks.
+import * as ExampleBlock from './blocks/example';
+
+const { registerBlockType } = wp.blocks;
+
+// Value of 'hm-blocks' theme supoort passed using localise script.
+const { HMCurrentThemeBlockSupport: enabledBlocks = [] } = window;
+
+// Map of block name to block options.
+const availableBlocks = {
+	[ExampleBlock.name]: ExampleBlock.options,
+}
+
+// Loop through enabled blocks, filter to check they exist and register the the.
+enabledBlocks.filter( name => !! availableBlocks[ name ] )
+	.forEach( name => registerBlockType( name, availableBlocks[ name ] ) );

--- a/content/mu-plugins/blocks/src/lib/readme.md
+++ b/content/mu-plugins/blocks/src/lib/readme.md
@@ -1,0 +1,3 @@
+# Lib
+
+Put any library code here.

--- a/content/mu-plugins/blocks/src/style.scss
+++ b/content/mu-plugins/blocks/src/style.scss
@@ -1,0 +1,6 @@
+@import "shared/visibility-control/style";
+@import "shared/server-side-render/style";
+@import "shared/card-control/style";
+@import "shared/post-select/style";
+@import "blocks/hero/style";
+@import "blocks/hockey-news/style";


### PR DESCRIPTION
For a recent project I Implemented the project structure as documented by [Joe McGill over on Dev H2](https://dev.hmn.md/2018/08/24/possible-gutenberg-setup/). I've gone ahead and put it together here. At least its something to get things started!

Intentionally missing is any webpack config. We can work on this separately.

Thoughts welcome!