### PR TITLE
Remove symlinks to outdated core themes

### DIFF
--- a/content/themes/twentyeleven
+++ b/content/themes/twentyeleven
@@ -1,1 +1,0 @@
-../../wordpress/wp-content/themes/twentyeleven/

--- a/content/themes/twentyten
+++ b/content/themes/twentyten
@@ -1,1 +1,0 @@
-../../wordpress/wp-content/themes/twentyten/

--- a/content/themes/twentythirteen
+++ b/content/themes/twentythirteen
@@ -1,1 +1,0 @@
-../../wordpress/wp-content/themes/twentythirteen/

--- a/content/themes/twentytwelve
+++ b/content/themes/twentytwelve
@@ -1,1 +1,0 @@
-../../wordpress/wp-content/themes/twentytwelve


### PR DESCRIPTION
Removes the symlinks to the the old, outdated core themes in the themes dir.

Resolves #82
