### PR TITLE
Add Test Suite Defaults

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,10 @@
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
 	>
+	<!-- Setup a constant for us to easily track when tests are running -->
+	<php>
+		<const name="RUNNING_UNIT_TESTS" value="true" />
+	</php>
 	<testsuites>
 		<!-- Default test suite to run all tests -->
 		<testsuite>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,7 +56,9 @@ tests_add_filter( 'pre_option_permalink_structure', function() {
  *
  * WordPress core runs a method (scan_user_uploads) on the first instance of
  * `WP_UnitTestCase`. This method scans every single folder and file in the
- * uploads directory.
+ * uploads directory. This becomes a problem with any significant quantity of
+ * uploads having been pulled into a local environment and has been
+ * known to take more than 5 minutes to run on certain local installs.
  *
  * This filter prevents any potential issues arising from running imports
  * locally and speeds up overall test execution. We do this by adding a unique

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,7 +22,7 @@ require_once $_tests_dir . '/includes/functions.php';
 /**
  * Disable update checks for core, themes, and plugins.
  *
- * No need for this work to happen when spinning up tests.
+ * There is no need for this work to happen when spinning up tests.
  */
 tests_add_filter( 'muplugins_loaded', function() {
 	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
@@ -37,6 +37,19 @@ tests_add_filter( 'muplugins_loaded', function() {
 
 	remove_action( 'wp_version_check', 'wp_version_check' );
 } );
+
+/**
+ * Set our permalink structure to always match production in tests.
+ *
+ * This prevent issues with permalink being set incorrectly, which affects any
+ * tests that rely on parsing or setting URLs. Update if your structure does not
+ * match the default.
+ *
+ * @return string.
+ */
+tests_add_filter( 'pre_option_permalink_structure', function() {
+	return '%year%/%monthnum%/%day%/%postname%';
+}, 99 ); // Ensure this fires late, after other filtering has occurred.
 
 /**
  * Re-map the default `/uploads` folder with our own `/test-uploads` for tests.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,7 +49,7 @@ tests_add_filter( 'muplugins_loaded', function() {
  */
 tests_add_filter( 'pre_option_permalink_structure', function() {
 	return '%year%/%monthnum%/%day%/%postname%';
-}, 99 ); // Ensure this fires late, after other filtering has occurred.
+}, 99 );
 
 /**
  * Re-map the default `/uploads` folder with our own `/test-uploads` for tests.
@@ -71,7 +71,7 @@ tests_add_filter( 'upload_dir', function( $dir ) {
 		}
 	} );
 	return $dir;
-}, 20 ); // Ensure this fires late, after other filtering has occurred.
+}, 20 );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,5 +38,25 @@ tests_add_filter( 'muplugins_loaded', function() {
 	remove_action( 'wp_version_check', 'wp_version_check' );
 } );
 
+/**
+ * Re-map the default `/uploads` folder with our own `/test-uploads` for tests.
+ *
+ * WordPress core runs a method (scan_user_uploads) on the first instance of
+ * `WP_UnitTestCase`. This method scans every single folder and file in the
+ * uploads directory.
+ *
+ * This filter prevents any potential issues arising from running imports
+ * locally and speeds up overall test execution. We do this by adding a unique
+ * test uploads folder just for our tests to reduce load.
+ */
+tests_add_filter( 'upload_dir', function( $dir ) {
+	array_walk( $dir, function( &$item ) {
+		if ( is_string( $item ) ) {
+			$item = str_replace( '/uploads', '/test-uploads', $item );
+		}
+	} );
+	return $dir;
+}, 20 ); // Ensure this fires late, after other filtering has occurred.
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,5 +19,24 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
+/**
+ * Disable update checks for core, themes, and plugins.
+ *
+ * No need for this work to happen when spinning up tests.
+ */
+tests_add_filter( 'muplugins_loaded', function() {
+	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
+	remove_action( 'wp_update_themes', 'wp_update_themes' );
+	remove_action( 'wp_update_plugins', 'wp_update_plugins' );
+
+	remove_action( 'admin_init', '_maybe_update_core' );
+	remove_action( 'admin_init', 'wp_maybe_auto_update' );
+	remove_action( 'admin_init', 'wp_auto_update_core' );
+	remove_action( 'admin_init', '_maybe_update_themes' );
+	remove_action( 'admin_init', '_maybe_update_plugins' );
+
+	remove_action( 'wp_version_check', 'wp_version_check' );
+} );
+
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,7 +41,7 @@ tests_add_filter( 'muplugins_loaded', function() {
 /**
  * Set our permalink structure to always match production in tests.
  *
- * This prevent issues with permalink being set incorrectly, which affects any
+ * This prevents issues with permalink being set incorrectly, which affects any
  * tests that rely on parsing or setting URLs. Update if your structure does not
  * match the default.
  *


### PR DESCRIPTION
There are several default filters and constants that have been using inconsistently across our projects in the past. This PR attempts to collect and collate them so that any new projects can pluck them from a consistent location.

Props @paulgibbs for the constant setting - neat idea!
Props @fklein-lu for several of the filters used here.